### PR TITLE
feature hashtag in comment

### DIFF
--- a/api-server/controllers/post.js
+++ b/api-server/controllers/post.js
@@ -244,8 +244,12 @@ exports.fetchSearched = async (req, res) => {
   // wordが ハッシュタグ : ハッシュタグ完全一致のみ検索
   //        ハッシュタグ以外 : mroongaからFETCH
   if (word.startsWith('#')) {
-    const postIds = await services.Post.fetchPostIdsFromHashtag(word)
-    where = { id: postIds, ...where }
+    const tag = word.replace('#', '') 
+    const postIds = await services.HashTag.fetchPostIds(tag)
+    const commentIds = await services.HashTag.fetchCommentIds(tag)
+    const commentPostIds = await services.Comment.fetchPostIds(commentIds) 
+    const targetPostIds = _.uniq([...postIds, ...commentPostIds])
+    where = { id: targetPostIds, ...where }
   } else {
     const postIds = await models.MroongaPost.findPostIds(word)
     where = { id: postIds, ...where }

--- a/api-server/migrations/201808161200-create-comment-hashtag.js
+++ b/api-server/migrations/201808161200-create-comment-hashtag.js
@@ -1,0 +1,40 @@
+const db = require('../models')
+const tableName = db.CommentHashtag.tableName
+
+module.exports = {
+  up: function(queryInterface, Sequelize) {
+    return queryInterface
+      .createTable(tableName, {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          primaryKey: true,
+          type: Sequelize.INTEGER
+        },
+        commentId: {
+          allowNull: false,
+          defaultValue: 0,
+          type: Sequelize.INTEGER
+        },
+        hashtagId: {
+          allowNull: false,
+          defaultValue: 0,
+          type: Sequelize.INTEGER
+        },
+
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE
+        }
+      })
+      .then(() => queryInterface.addIndex(tableName, { fields: ['commentId'] }))
+      .then(() => queryInterface.addIndex(tableName, { fields: ['hashtagId'] }))
+  },
+  down: function(queryInterface, Sequelize) {
+    return queryInterface.dropTable(tableName)
+  }
+}

--- a/api-server/models/comment_hashtag.js
+++ b/api-server/models/comment_hashtag.js
@@ -1,0 +1,13 @@
+module.exports = function(sequelize, DataTypes) {
+  var CommentHashtag = sequelize.define(
+    'CommentHashtag',
+    {
+      commentId: DataTypes.INTEGER,
+      hashtagId: DataTypes.INTEGER
+    },
+    {
+      tableName: 'CommentHashtags'
+    }
+  )
+  return CommentHashtag
+}

--- a/api-server/models/comment_hashtag.js
+++ b/api-server/models/comment_hashtag.js
@@ -6,7 +6,7 @@ module.exports = function(sequelize, DataTypes) {
       hashtagId: DataTypes.INTEGER
     },
     {
-      tableName: 'CommentHashtags'
+      tableName: 'CommentsHashtags'
     }
   )
   return CommentHashtag

--- a/api-server/services/Comment.js
+++ b/api-server/services/Comment.js
@@ -35,7 +35,6 @@ module.exports = class Comment {
       const hashtags = HashtagService.findTagsFrom(body)
       {
         const hashtagIds = await HashtagService.upsert(hashtags, transaction)
-        // TODO: commentとhashtagの関係性をどうするか？
         await Comment.updateCommentHashtagRelation(comment.id, hashtagIds, transaction)
       }
 

--- a/api-server/services/HashTag.js
+++ b/api-server/services/HashTag.js
@@ -1,0 +1,126 @@
+const reqlib = require('app-root-path').require
+const _ = require('lodash')
+const hashtagRegex = require('hashtag-regex')
+const models = reqlib('/models')
+
+/**
+ * Tagの管理用service
+ */
+module.exports = class HashTag {
+    /**
+     * 記事本文からHashtag情報を解析し、Hashtagテーブルに保存
+     * @param {*} tags 
+     * @param {*} transaction 
+     */
+  static async upsert(tags, transaction) {
+    // 既存タグ
+    const existingTags = await models.Hashtag.findAll({
+      where: { name: tags }
+    })
+    const existingTagIds = _.map(existingTags, 'id')
+    // console.log('existingTagIds', existingTagIds)
+
+    // 新規タグ（入力タグから、既存タグの差をとったものを新規とみなす）
+    const newTagNames = _.difference(tags, _.map(existingTags, 'name'))
+    const newTagRows = await models.Hashtag.bulkCreate(
+      newTagNames.map(str => {
+        return { name: str }
+      }),
+      {
+        raw: true,
+        transaction
+      }
+    )
+    const newTgsIds = _.map(newTagRows, 'id')
+    // console.log('newTgsIds', newTgsIds)
+
+    return [...existingTagIds, ...newTgsIds]
+  }
+
+  /**
+   * bodyに含まれている # から始まる 文字列のリストを取得
+   * # から始まって （半角|全角）スペース で終わる文字列をハッシュタグとして認識する
+   * @param {String} body 
+   * @returns {Array<String>} タグリスト
+   */
+  static findTagsFrom(text) {
+    let result = []
+    const regex = hashtagRegex()
+
+    let match
+    while ((match = regex.exec(text))) {
+      // # 記号は省く
+      result.push(match[0].replace('#', ''))
+    }
+
+    return _.uniq(result)
+  }
+
+  /**
+   * TagとPostの紐づけ
+   * @param {int} postId 
+   * @param {Array<int>} tagIds 
+   * @param {*} transaction 
+   */
+  static async updatePostHashtag(postId, tagIds, transaction) {
+    // まず既存のタグ関係を削除
+    await models.PostHashtag.destroy({ where: { postId } }, { transaction })
+    // その後INSERT
+    const data = tagIds.map(tagId => {
+      return {
+        postId,
+        tagId
+      }
+    })
+    await models.PostHashtag.bulkCreate(data, { transaction })
+  }
+
+  /**
+   * CommentとTagの紐づけ
+   * @param {int} commentId 
+   * @param {Array<int>} tagIds 
+   * @param {*} transaction 
+   */
+  static async updateCommentHashtag(commentId, tagIds, transaction) {
+    // まず既存のタグ関係を削除
+    await models.CommentHashtag.destroy({ where: { postId } }, { transaction })
+    // その後INSERT
+    const data = tagIds.map(tagId => {
+      return {
+        commentId,
+        tagId
+      }
+    })
+    await models.CommentHashtag.bulkCreate(data, { transaction })
+  }
+
+  /**
+   * タグからPostIdsを取得する
+   * @param {string} tag
+   * @returns {Array<int>} postIds 
+   */
+  static async fetchPostIds(name) {
+    const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
+    const tagIds = _.map(tags, 'id')
+    const postsTags = await models.PostHashtag.findAll({
+      where: { hashtagId: tagIds },
+      raw: true
+    })
+    return _.uniq(_.map(postsTags, 'postId'))
+  }
+
+  /**
+   * タグが使われているコメントのIDのリストを取得
+   * @param {string} tag 
+   * @returns {Array<int>} commentIds
+   */
+  static async fetchCommentIds(name) {
+    const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
+    const tagIds = _.map(tags, 'id')
+    const commentTags = await models.CommentHashtag.findAll({
+      where: { hashtagId: tagIds },
+      raw: true
+    })
+    return _.uniq(_.map(commentTags, 'commentId'))
+  }
+}

--- a/api-server/services/HashTag.js
+++ b/api-server/services/HashTag.js
@@ -96,7 +96,7 @@ module.exports = class HashTag {
 
   /**
    * タグからPostIdsを取得する
-   * @param {string} tag
+   * @param {string} name
    * @returns {Array<int>} postIds 
    */
   static async fetchPostIds(name) {
@@ -111,7 +111,7 @@ module.exports = class HashTag {
 
   /**
    * タグが使われているコメントのIDのリストを取得
-   * @param {string} tag 
+   * @param {string} name 
    * @returns {Array<int>} commentIds
    */
   static async fetchCommentIds(name) {

--- a/api-server/services/HashTag.js
+++ b/api-server/services/HashTag.js
@@ -7,11 +7,11 @@ const models = reqlib('/models')
  * Tagの管理用service
  */
 module.exports = class HashTag {
-    /**
-     * 記事本文からHashtag情報を解析し、Hashtagテーブルに保存
-     * @param {*} tags 
-     * @param {*} transaction 
-     */
+  /**
+   * 記事本文からHashtag情報を解析し、Hashtagテーブルに保存
+   * @param {*} tags
+   * @param {*} transaction
+   */
   static async upsert(tags, transaction) {
     // 既存タグ
     const existingTags = await models.Hashtag.findAll({
@@ -31,16 +31,15 @@ module.exports = class HashTag {
         transaction
       }
     )
-    const newTgsIds = _.map(newTagRows, 'id')
-    // console.log('newTgsIds', newTgsIds)
+    const newTagsIds = _.map(newTagRows, 'id')
 
-    return [...existingTagIds, ...newTgsIds]
+    return [...existingTagIds, ...newTagsIds]
   }
 
   /**
    * bodyに含まれている # から始まる 文字列のリストを取得
    * # から始まって （半角|全角）スペース で終わる文字列をハッシュタグとして認識する
-   * @param {String} body 
+   * @param {String} body
    * @returns {Array<String>} タグリスト
    */
   static findTagsFrom(text) {
@@ -58,9 +57,9 @@ module.exports = class HashTag {
 
   /**
    * TagとPostの紐づけ
-   * @param {int} postId 
-   * @param {Array<int>} tagIds 
-   * @param {*} transaction 
+   * @param {int} postId
+   * @param {Array<int>} tagIds
+   * @param {*} transaction
    */
   static async updatePostHashtag(postId, tagIds, transaction) {
     // まず既存のタグ関係を削除
@@ -77,9 +76,9 @@ module.exports = class HashTag {
 
   /**
    * CommentとTagの紐づけ
-   * @param {int} commentId 
-   * @param {Array<int>} tagIds 
-   * @param {*} transaction 
+   * @param {int} commentId
+   * @param {Array<int>} tagIds
+   * @param {*} transaction
    */
   static async updateCommentHashtag(commentId, tagIds, transaction) {
     // まず既存のタグ関係を削除
@@ -97,7 +96,7 @@ module.exports = class HashTag {
   /**
    * タグからPostIdsを取得する
    * @param {string} name
-   * @returns {Array<int>} postIds 
+   * @returns {Array<int>} postIds
    */
   static async fetchPostIds(name) {
     const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
@@ -111,7 +110,7 @@ module.exports = class HashTag {
 
   /**
    * タグが使われているコメントのIDのリストを取得
-   * @param {string} name 
+   * @param {string} name
    * @returns {Array<int>} commentIds
    */
   static async fetchCommentIds(name) {

--- a/api-server/services/Post.js
+++ b/api-server/services/Post.js
@@ -159,17 +159,6 @@ module.exports = class Post {
     }
   }
 
-  // static async fetchPostIdsFromHashtag(word) {
-  //   const name = word.replace('#', '')
-  //   const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
-  //   const tagIds = _.map(tags, 'id')
-  //   const postsTags = await models.PostHashtag.findAll({
-  //     where: { hashtagId: tagIds },
-  //     raw: true
-  //   })
-  //   return _.uniq(_.map(postsTags, 'postId'))
-  // }
-
   // 投票（UPDATE対応済）
   static async saveVote(postId, voterId, brandId, choiceIndex, comment) {
     // 初投票ならtrue, 更新ならfalse

--- a/api-server/services/Post.js
+++ b/api-server/services/Post.js
@@ -1,9 +1,9 @@
 const reqlib = require('app-root-path').require
 const _ = require('lodash')
-const hashtagRegex = require('hashtag-regex')
 const UserService = reqlib('/services/User')
 const BadgeService = reqlib('/services/Badge')
 const CommentService = reqlib('/services/Comment')
+const HashtagService = reqlib('/services/HashTag')
 const NotificationService = reqlib('/services/Notification')
 const { moveImage, moveImages } = reqlib('/utils/image')
 const models = reqlib('/models')
@@ -75,9 +75,9 @@ module.exports = class Post {
       }
 
       // Hashtagsテーブル更新。各々のタグに関して新規:INSERT。既存:find tagId
-      const hashtags = Post.getHashtags(body)
+      const hashtags = HashtagService.findTagsFrom(body)
       {
-        const hashtagIds = await Post.upsertHashtags(hashtags, transaction)
+        const hashtagIds = await HashtagService.upsert(hashtags, transaction)
         await Post.updatePostHashtagRelation(postId, hashtagIds, transaction)
       }
 
@@ -159,15 +159,16 @@ module.exports = class Post {
     }
   }
 
-  static async fetchPostIdsFromHashtag(word) {
-    const name = word.replace('#', '')
-    const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
-    const postsTags = await models.PostHashtag.findAll({
-      where: { hashtagId: _.map(tags, 'id') },
-      raw: true
-    })
-    return _.map(postsTags, 'postId')
-  }
+  // static async fetchPostIdsFromHashtag(word) {
+  //   const name = word.replace('#', '')
+  //   const tags = await models.Hashtag.findAll({ where: { name }, raw: true })
+  //   const tagIds = _.map(tags, 'id')
+  //   const postsTags = await models.PostHashtag.findAll({
+  //     where: { hashtagId: tagIds },
+  //     raw: true
+  //   })
+  //   return _.uniq(_.map(postsTags, 'postId'))
+  // }
 
   // 投票（UPDATE対応済）
   static async saveVote(postId, voterId, brandId, choiceIndex, comment) {
@@ -339,47 +340,6 @@ module.exports = class Post {
   // sequelizeで count クエリを発行するための関数
   static getCountAttr() {
     return [models.sequelize.fn('COUNT', models.sequelize.col('id')), 'count']
-  }
-
-  // 記事本文からHashtag情報を解析し、Hashtagテーブルに保存
-  static async upsertHashtags(tags, transaction) {
-    // 既存タグ
-    const existingTags = await models.Hashtag.findAll({
-      where: { name: tags }
-    })
-    const existingTagIds = _.map(existingTags, 'id')
-    // console.log('existingTagIds', existingTagIds)
-
-    // 新規タグ（入力タグから、既存タグの差をとったものを新規とみなす）
-    const newTagNames = _.difference(tags, _.map(existingTags, 'name'))
-    const newTagRows = await models.Hashtag.bulkCreate(
-      newTagNames.map(str => {
-        return { name: str }
-      }),
-      {
-        raw: true,
-        transaction
-      }
-    )
-    const newTgsIds = _.map(newTagRows, 'id')
-    // console.log('newTgsIds', newTgsIds)
-
-    return [...existingTagIds, ...newTgsIds]
-  }
-
-  // # から始まって （半角|全角）スペース で終わる文字列をハッシュタグとして認識する
-  static getHashtags(body) {
-    let result = []
-    const regex = hashtagRegex()
-
-    let match
-    while ((match = regex.exec(body))) {
-      // # 記号は省く
-      result.push(match[0].replace('#', ''))
-    }
-    console.log('Hashtag parsed', result)
-
-    return _.uniq(result)
   }
 
   static async updatePostHashtagRelation(postId, hashtagIds, transaction) {

--- a/api-server/services/index.js
+++ b/api-server/services/index.js
@@ -1,15 +1,12 @@
-const User = require('./User')
-const Post = require('./Post')
-const Badge = require('./Badge')
-const Comment = require('./Comment')
-const Invitation = require('./Invitation')
-const Notification = require('./Notification')
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
 
-module.exports = {
-  User,
-  Post,
-  Badge,
-  Comment,
-  Invitation,
-  Notification
-}
+// services配下にあるfileをexports登録
+_.forEach(fs.readdirSync(__dirname), (filename) => {
+  if (path.extname(filename) !== '.js' || filename === 'index.js' || filename === 'passports.js') {
+    return;
+  }
+  const jsname = path.basename(filename, '.js');
+  module.exports[jsname] = require(`./${filename}`);
+});

--- a/api-server/services/index.js
+++ b/api-server/services/index.js
@@ -1,12 +1,16 @@
-const fs = require('fs');
-const path = require('path');
-const _ = require('lodash');
+const fs = require('fs')
+const path = require('path')
+const _ = require('lodash')
 
 // services配下にあるfileをexports登録
-_.forEach(fs.readdirSync(__dirname), (filename) => {
-  if (path.extname(filename) !== '.js' || filename === 'index.js' || filename === 'passports.js') {
-    return;
+_.forEach(fs.readdirSync(__dirname), filename => {
+  if (
+    path.extname(filename) !== '.js' ||
+    filename === 'index.js' ||
+    filename === 'passports.js'
+  ) {
+    return
   }
-  const jsname = path.basename(filename, '.js');
-  module.exports[jsname] = require(`./${filename}`);
-});
+  const jsname = path.basename(filename, '.js')
+  module.exports[jsname] = require(`./${filename}`)
+})

--- a/react-web/components/organisms/site/box/CommentZone.js
+++ b/react-web/components/organisms/site/box/CommentZone.js
@@ -8,6 +8,7 @@ import { Link } from 'routes'
 import { AppPost } from 'constants/ActionTypes'
 import Avatar from 'components/atoms/Avatar'
 import ReadMoreAndLoading from 'components/molecules/ReadMoreAndLoading'
+import MultiLineHashtagText from 'components/atoms/MultiLineHashtagText'
 
 // ページ番号は1から
 const INITIAL_PAGE = 1
@@ -28,7 +29,9 @@ class Comments extends React.Component {
           <Link route={`/view/mypage/${e.commenterId}`}>
             <a>{e.name}</a>
           </Link>
-          <div>{e.body}</div>
+          <div>
+            <MultiLineHashtagText>{e.body}</MultiLineHashtagText>
+          </div>
         </div>
 
         <style jsx>{`


### PR DESCRIPTION
```
コメント内にある♯もハッシュタグとして機能させる(今は投稿のもののみハッシュタグとして機能)
```

行った変更

##　機能追加関連
- services/Hashtagを作成
- services/Postで行っていたHashtagの処理をHashtagサービスに移動
- CommentHashtagｓテーブルを作成
- ハッシュタグの検索結果の対象にコメントにハッシュタグが含まれている記事も表示する

## コード改善
- services/index.jsを修正し、ファイルを確認しファイルがあったらexportsする方法に変更

## テスト
local環境
- [x] コメントにハッシュタグとして表示される
- [x] コメントのハッシュタグがリンクとして表示される
- [x] ハッシュタグから検索結果に遷移する
- [x] ハッシュタグが入ったコメントを含む記事も表示される