### PR TITLE
add feature mention server side

### DIFF
--- a/api-server/package-lock.json
+++ b/api-server/package-lock.json
@@ -3217,6 +3217,11 @@
         "timers-ext": "^0.1.2"
       }
     },
+    "mentions-regex": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mentions-regex/-/mentions-regex-2.0.3.tgz",
+      "integrity": "sha1-RCcXoASOU8LS4q5eY6TlSlXKlgM="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",

--- a/api-server/package.json
+++ b/api-server/package.json
@@ -28,6 +28,7 @@
     "hashtag-regex": "^2.0.0",
     "jwt-simple": "^0.5.1",
     "lodash": "^4.17.10",
+    "mentions-regex": "^2.0.3",
     "moment": "^2.22.2",
     "morgan": "^1.9.0",
     "move-file": "^1.0.0",

--- a/api-server/services/HashTag.js
+++ b/api-server/services/HashTag.js
@@ -81,8 +81,6 @@ module.exports = class HashTag {
    * @param {*} transaction
    */
   static async updateCommentHashtag(commentId, tagIds, transaction) {
-    // まず既存のタグ関係を削除
-    await models.CommentHashtag.destroy({ where: { postId } }, { transaction })
     // その後INSERT
     const data = tagIds.map(tagId => {
       return {

--- a/api-server/services/Mention.js
+++ b/api-server/services/Mention.js
@@ -1,0 +1,40 @@
+const reqlib = require('app-root-path').require
+const NotificationService = reqlib('/services/Notification')
+const Rule = reqlib('/../shared/constants/Rule')
+const models = reqlib('/models')
+
+module.exports = class Mention {
+  /**
+   * テキスト内容から`@`で始まりスペースが終わるまでのstringをリストとして返却する
+   * ex) @aaa @bbb -> ['aaa', 'bbb']
+   * @param {string} text
+   * @returns {Arrya<string>} result
+   */
+  static regex(text) {
+    const pattern = /\B@[a-z0-9_-]+/gi
+    return text.match(pattern).map(mention => mention.replace('@', ''))
+  }
+
+  /**
+   *
+   * @param {*} targetUserIds
+   * @param {*} data,
+   * @param {Object} options
+   * @param {Object} options.transaction
+   */
+  static async sendNotifications(targetUserIds, data, options) {
+    if (!data) return false
+    const userIds = await models.User.findAll({
+      where: { id: targetUserIds }
+    }).map(data => data.id)
+
+    console.log(targetUserIds, userIds)
+    await userIds.forEach(targetUserId => {
+      NotificationService.save(
+        Rule.NOTIFICATION_TYPE.Mention,
+        Object.assign({}, data, { targetUserId }),
+        options
+      )
+    })
+  }
+}

--- a/api-server/services/Post.js
+++ b/api-server/services/Post.js
@@ -5,6 +5,7 @@ const BadgeService = reqlib('/services/Badge')
 const CommentService = reqlib('/services/Comment')
 const HashtagService = reqlib('/services/HashTag')
 const NotificationService = reqlib('/services/Notification')
+const MentionService = reqlib('/services/Mention')
 const { moveImage, moveImages } = reqlib('/utils/image')
 const models = reqlib('/models')
 const Path = reqlib('/constants/Path')
@@ -79,6 +80,23 @@ module.exports = class Post {
       {
         const hashtagIds = await HashtagService.upsert(hashtags, transaction)
         await Post.updatePostHashtagRelation(postId, hashtagIds, transaction)
+      }
+
+      // mentionの処理
+      const mentions = MentionService.regex(body)
+      if (mentions) {
+        const notificationBase = {
+          type: Rule.NOTIFICATION_TYPE.Mention,
+          postId,
+          targetUserId: null,
+          actionUserId: userId,
+          brandId
+        }
+        await MentionService.sendNotifications(
+          _.uniq(mentions),
+          notificationBase,
+          { transaction }
+        )
       }
 
       // mroongaへ同期（完了を待つ必要なし）
@@ -245,11 +263,12 @@ module.exports = class Post {
       // 初回LIKE時
       if (created) {
         // update Notification table (not wait the operation)
+
+        // TODO 'models.Post.update' でもデータ取れるか確認する
+        const targetUserId = await models.Post.findById(postId).posterId
         await NotificationService.save(
           Rule.NOTIFICATION_TYPE.Like,
-          postId,
-          userId,
-          brandId,
+          { postId, targetUserId, actionUserId: userId, brandId },
           { transaction }
         )
 

--- a/react-web/pages/view/notification.js
+++ b/react-web/pages/view/notification.js
@@ -15,6 +15,8 @@ const Contents = props => {
         return 'いいね！'
       case Rule.NOTIFICATION_TYPE.Comment:
         return 'コメント'
+      case Rule.NOTIFICATION_TYPE.Mention:
+        return 'メンション' // TODO: ラベルの再考慮
       default:
         return ''
     }

--- a/shared/constants/Rule.js
+++ b/shared/constants/Rule.js
@@ -13,5 +13,5 @@ module.exports = {
   CATNAME_MAX_LENGTH: 15,
 
   // 通知種別
-  NOTIFICATION_TYPE: { Default: 0, Like: 1, Comment: 2, News: 3 }
+  NOTIFICATION_TYPE: { Default: 0, Like: 1, Comment: 2, News: 3, Mention: 4 }
 }


### PR DESCRIPTION
```
・投稿、コメント中で@でユーザーにメンションしたい(付随して通知が行くようにしたい)
```

#　行ったこと
- 投稿、コメント中で '@ユーザー名' メンションができる
- そのユーザー名を持っているユーザーに対して通知が飛ぶ

#　テスト
- [x] 投稿に`@ユーザー名` で通知が飛ぶか？
- [x] コメントに `@ユーザー名` で通知が飛ぶか？

#　メモ
- 今回の懸念事項
	- nicknameが現状uniqueではないので、今後どうするのか仕様判断が必要

- クライアント側の実装はもう少し中身が詰まってから
	- mentionのリンク先
	- いない存在しないユーザー名に対してメンションをつけたときどうするか？
	- mentionを行うときのinput時に補完がほしいか？
